### PR TITLE
docs: update demo url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A final site for Mirror sites.
 
 ## Demo
 
-<https://mirrorz.org> and <https://mirrors.cernet.edu.cn>
+<https://mirrorz.org> and <https://mirrors.cernet.edu.cn/list>
 
 Also legacy webpages (for w3m and noscript users) are provided in <https://mirrorz.org/_/> and <https://mirrors.cernet.edu.cn/_/>
 


### PR DESCRIPTION
Now, https://mirrors.cernet.edu.cn returns a 302 response, which redirects to https://help.mirrors.cernet.edu.cn/
So the demo url of MirrorZ needs to be changed to https://mirrors.cernet.edu.cn/list